### PR TITLE
Allow URL parameters for query matching

### DIFF
--- a/YandexMusicResolver.Tests/MainResolverTest.cs
+++ b/YandexMusicResolver.Tests/MainResolverTest.cs
@@ -5,10 +5,12 @@ using YandexMusicResolver.AudioItems;
 
 namespace YandexMusicResolver.Tests;
 
-public class MainResolverTest : YandexTestBase{
+public class MainResolverTest : YandexTestBase
+{
     [Theory]
     [InlineData("https://music.yandex.ru/album/9425747/track/55561798")]
-    public async Task GetTrack(string url) {
+    public async Task GetTrack(string url)
+    {
         var audioItem = await MainResolver.ResolveQuery(url);
         Assert.NotNull(audioItem);
         Assert.False(audioItem.IsSearchResult);
@@ -18,10 +20,11 @@ public class MainResolverTest : YandexTestBase{
         Assert.NotEmpty(audioItem.Tracks);
         Assert.Equal(YandexSearchType.Track, YandexSearchType.Track);
     }
-        
+
     [Theory]
     [InlineData("https://music.yandex.ru/album/9425747")]
-    public async Task GetAlbum(string url) {
+    public async Task GetAlbum(string url)
+    {
         var audioItem = await MainResolver.ResolveQuery(url);
         Assert.NotNull(audioItem);
         Assert.False(audioItem.IsSearchResult);
@@ -31,10 +34,11 @@ public class MainResolverTest : YandexTestBase{
         Assert.NotEmpty(audioItem.Albums);
         Assert.Equal(YandexSearchType.Album, audioItem.Type);
     }
-        
+
     [Theory]
     [InlineData("https://music.yandex.ru/users/enlivenbot/playlists/1000")]
-    public async Task GetPlaylist(string url) {
+    public async Task GetPlaylist(string url)
+    {
         var audioItem = await MainResolver.ResolveQuery(url);
         Assert.NotNull(audioItem);
         Assert.False(audioItem.IsSearchResult);
@@ -48,8 +52,10 @@ public class MainResolverTest : YandexTestBase{
     [Theory]
     [InlineData("Take over")]
     [InlineData("ymsearch:Track:10:Take over")]
-    public async Task TestDisabledSearch(string query) {
-        var yandexMusicMainResolver = YandexMusicMainResolver.Create(YandexCredentialsProviderMock.Object, new HttpClient());
+    public async Task TestDisabledSearch(string query)
+    {
+        var yandexMusicMainResolver =
+            YandexMusicMainResolver.Create(YandexCredentialsProviderMock.Object, new HttpClient());
         yandexMusicMainResolver.AllowSearch = false;
         var audioItem = await yandexMusicMainResolver.ResolveQuery(query);
         Assert.Null(audioItem);
@@ -58,8 +64,10 @@ public class MainResolverTest : YandexTestBase{
     [Theory]
     [InlineData("Take over", true)]
     [InlineData("ymsearch:Track:10:Take over", false)]
-    public async Task TestDisabledPlainTextSearch(string query, bool isPlainText) {
-        var yandexMusicMainResolver = YandexMusicMainResolver.Create(YandexCredentialsProviderMock.Object, new HttpClient());
+    public async Task TestDisabledPlainTextSearch(string query, bool isPlainText)
+    {
+        var yandexMusicMainResolver =
+            YandexMusicMainResolver.Create(YandexCredentialsProviderMock.Object, new HttpClient());
         yandexMusicMainResolver.PlainTextIsSearchQuery = false;
         var audioItem = await yandexMusicMainResolver.ResolveQuery(query);
         Assert.Equal(isPlainText, audioItem == null);
@@ -67,9 +75,29 @@ public class MainResolverTest : YandexTestBase{
 
     [Theory]
     [InlineData("Take Over")]
-    public async Task TestSearch(string url) {
+    public async Task TestSearch(string url)
+    {
+        MainResolver.PlainTextIsSearchQuery = true;
         var audioItem = await MainResolver.ResolveQuery(url);
         Assert.NotNull(audioItem);
         Assert.IsType<YandexMusicSearchResult>(audioItem);
+    }
+
+    [Theory]
+    [InlineData("https://music.yandex.ru/album/9425747/track/55561798")]
+    [InlineData("https://music.yandex.ru/album/9425747")]
+    [InlineData("https://music.yandex.ru/users/enlivenbot/playlists/1000")]
+    [InlineData("ymsearch:Track:10:Take over")]
+    [InlineData("https://music.yandex.ru/album/36938610/track/139888583?utm_source=desktop&utm_medium=copy_link")]
+    public void CanResolveQuery(string url)
+    {
+        Assert.True(MainResolver.CanResolveQuery(url));
+    }
+
+    [Theory]
+    [InlineData("some text")]
+    public void CantResolveQuery(string url)
+    {
+        Assert.False(MainResolver.CanResolveQuery(url));
     }
 }

--- a/YandexMusicResolver.Tests/YandexTestBase.cs
+++ b/YandexMusicResolver.Tests/YandexTestBase.cs
@@ -14,5 +14,6 @@ public class YandexTestBase {
     public YandexTestBase() {
         YandexCredentialsProviderMock = AutoMocker.GetMock<IYandexCredentialsProvider>();
         MainResolver = YandexMusicMainResolver.Create(YandexCredentialsProviderMock.Object, new HttpClient());
+        MainResolver.PlainTextIsSearchQuery = false;
     }
 }

--- a/YandexMusicResolver/YandexMusicMainResolver.cs
+++ b/YandexMusicResolver/YandexMusicMainResolver.cs
@@ -11,9 +11,9 @@ namespace YandexMusicResolver;
 
 /// <inheritdoc />
 public sealed class YandexMusicMainResolver : IYandexMusicMainResolver {
-    private const string TrackUrlPattern = "^https?://music\\.yandex\\.[a-zA-Z]+/album/([0-9]+)/track/([0-9]+)$";
-    private const string AlbumUrlPattern = "^https?://music\\.yandex\\.[a-zA-Z]+/album/([0-9]+)$";
-    private const string PlaylistUrlPattern = "^https?://music\\.yandex\\.[a-zA-Z]+/users/(.+)/playlists/([0-9]+)$";
+    private const string TrackUrlPattern = @"^https?://music\.yandex\.[a-zA-Z]+/album/([0-9]+)/track/([0-9]+)";
+    private const string AlbumUrlPattern = @"^https?://music\.yandex\.[a-zA-Z]+/album/([0-9]+)";
+    private const string PlaylistUrlPattern = @"^https?://music\.yandex\.[a-zA-Z]+/users/(.+)/playlists/([0-9]+)";
 
     private static readonly Regex TrackUrlRegex = new(TrackUrlPattern);
     private static readonly Regex AlbumUrlRegex = new(AlbumUrlPattern);


### PR DESCRIPTION
Allows https://music.yandex.ru/album/36938610/track/139888583?utm_source=desktop&utm_medium=copy_link to be parsed